### PR TITLE
Throw error instead of emit outside of stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,9 +25,8 @@ function gulpVueify (options) {
     }
     compiler.compile(file.contents.toString(), file.path, function (err, result) {
       if (err) {
-        this.emit('error', new PluginError(PLUGIN_NAME,
-          'In file ' + path.relative(process.cwd(), file.path) + ':\n' + err.message));
-        return callback();
+        throw new PluginError(PLUGIN_NAME,
+          'In file ' + path.relative(process.cwd(), file.path) + ':\n' + err.message);
       }
       file.path = gutil.replaceExtension(file.path, '.js');
       file.contents = new Buffer(result);


### PR DESCRIPTION
Some errors are going unreported because they are not being thrown. Gulp docs indicate they should be thrown if not in stream.

In my case the compile error "You are trying to use "hot-reload". vue-hot-reload-api is missing. ..." was causing gulp to die silently. The change above properly reports the error.
