### PR TITLE
update version of vueify for vue2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-vueify",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Compile .vue files using vueify",
   "main": "index.js",
   "scripts": {
@@ -18,6 +18,6 @@
   "dependencies": {
     "gulp-util": "^3.0.7",
     "through2": "^2.0.1",
-    "vueify": "^8.3.5"
+    "vueify": "^9.4.0"
   }
 }


### PR DESCRIPTION
fixed the error when use Vue2 runtime-only ,  #6

> Failed to mount component: template or render function not defined.

  